### PR TITLE
Add support for dark theme

### DIFF
--- a/extension/load.html
+++ b/extension/load.html
@@ -2,7 +2,7 @@
 <head>
   <style>
   table, td, th {
-    border: 1px solid #ddd;
+    border: 1px solid rgba(100, 100, 100, 0.2);
   }
 
   th .popup {
@@ -35,15 +35,17 @@
 
   table {
     border-collapse: collapse;
+    color: inherit;
     width: 100%;
   }
 
   th, td {
+    color: inherit;
     padding: 15px;
   }
 
   #measures tr:nth-child(even){
-    background-color: #f2f2f2;
+    background-color: rgba(100, 100, 100, 0.2);
   }
 
   button {

--- a/src/components/ReactPerfDevtool.js
+++ b/src/components/ReactPerfDevtool.js
@@ -135,8 +135,13 @@ class ReactPerfDevtool extends React.Component {
   };
 
   render() {
+    console.log(chrome.devtools);
     return (
-      <div>
+      <div
+        style={{
+          color: chrome.devtools.panels.themeName === "dark" ? "white" : "black"
+        }}
+      >
         <div style={{ display: "inlineBlock" }}>
           <button onClick={this.clear}>Clear</button>
           <button onClick={this.reload}>Reload the inspected page</button>


### PR DESCRIPTION
This commit adds support for theming - the extension now works with
the Chrome dark theme.

This is how it looks with dark theme:

![image](https://user-images.githubusercontent.com/1307267/34103488-262bb336-e3ed-11e7-8614-71019ee562e0.png)

This is how it looks with the default theme:

![image](https://user-images.githubusercontent.com/1307267/34103514-3a5ac31a-e3ed-11e7-8be8-cb3000031ad3.png)
