### PR TITLE
Fix/dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": ["src"],
   "author": "Nitin Tulswani",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "prop-types": "^15.6.0",
     "react-test-renderer": "^16.2.0",
     "uglifyjs-webpack-plugin": "^1.1.2",
-    "webpack": "^3.10.0"
+    "webpack": "^3.10.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
I believe this project shouldn't depend directly (by doing so adding to node_modules) on react and react-dom.
The only code that requires them are on tests (so that make them dev dependencies).
Since it works like a plugin on top of react, it should have them as a peer dependencies: https://nodejs.org/en/blog/npm/peer-dependencies/
So other projects that use this project should have the actual responsibility of including react and react-dom on node_modules.