### PR TITLE
Prevent PerformanceObserver from getting destroyed over time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Registering an observer is very simple and is only one function call away. Let's
 ```js
 const { registerObserver } = require('react-perf-devtool')
 
-registerObserver()
+window.observer = registerObserver()
 ```
 
 You can place this code inside your `index.js` file (recommended) or any other file in your app.
@@ -141,7 +141,7 @@ function callback(measures) {
   // do something with the measures
 }
 
-registerObserver({}, callback)
+window.observer = registerObserver({}, callback)
 ```
 
 After you've registered the observer, start your local development server and go to `http://localhost:3000/?react_perf`.
@@ -200,7 +200,7 @@ function callback(measures) {
   // do something with the measures
 }
 
-registerObserver(options, callback)
+window.observer = registerObserver(options, callback)
 
 ReactDOM.render(<Component />, document.getElementById('root'))
 ```

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -31,12 +31,12 @@ import { generateDataFromMeasures } from '../shared/generate'
 */
 const registerObserver = (params, callback) => {
   params = params || {}
-
+  let observer = null
   // TODO: Is there any way to polyfill this API ?
   if (window.PerformanceObserver) {
     const { shouldLog, port, components } = params
 
-    let observer = new window.PerformanceObserver(list => {
+    observer = new window.PerformanceObserver(list => {
       const measures = generateDataFromMeasures(
         getReactPerformanceData(list.getEntries())
       )
@@ -61,6 +61,7 @@ const registerObserver = (params, callback) => {
       entryTypes: ['measure']
     })
   }
+  return observer
 }
 
 /**


### PR DESCRIPTION
See issue #25 .
This is only meant to illustrate the issue and a workaround, not a final solution.