### PR TITLE
refactor: change implementation required measures

### DIFF
--- a/__tests__/logMeasures.js
+++ b/__tests__/logMeasures.js
@@ -49,13 +49,13 @@ function logToConsole({ port, components }, measures) {
   if (!components) {
     logMeasures(measures)
   } else if (typeof components !== undefined && Array.isArray(components)) {
-    var stats = getRequiredMeasures(components, measures)
+    var stats = getMeasuresByComponentName(components, measures)
 
     logMeasures(stats)
   }
 }
 
-function getRequiredMeasures(components, measures) {
+function getMeasuresByComponentName(components, measures) {
   var requiredMeasures = []
 
   if (!Array.isArray(components)) {

--- a/__tests__/registerObserver.test.js
+++ b/__tests__/registerObserver.test.js
@@ -1,4 +1,4 @@
-var { registerObserver } = require('../src/npm/hook')
+var { registerObserver, getRequiredMeasures } = require('../src/npm/hook')
 
 describe('Register Observer', () => {
   describe('The register observer function shouldnt crash', () => {
@@ -29,6 +29,46 @@ describe('Register Observer', () => {
       const callback = () => {}
       expect(registerObserver(undefined, callback)).toBeUndefined()
       expect(window.PerformanceObserver).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('utils', () => {
+  let componentNames
+  let measures
+  let requiredMeasures
+  describe('getRequiredMeasures', () => {
+    describe('with matching `componentNames`', () => {
+      beforeEach(() => {
+        componentNames = ['foo']
+        measures = [
+          {
+            componentName: 'foo'
+          }
+        ]
+        requiredMeasures = getRequiredMeasures(componentNames, measures)
+      })
+      it('should return a list of required measure', () => {
+        expect(requiredMeasures).toEqual([
+          {
+            componentName: 'foo'
+          }
+        ])
+      })
+    })
+    describe('without matching `componentNames`', () => {
+      beforeEach(() => {
+        componentNames = ['foo']
+        measures = [
+          {
+            componentName: 'bar'
+          }
+        ]
+        requiredMeasures = getRequiredMeasures(componentNames, measures)
+      })
+      it('should return a list of empty measure', () => {
+        expect(requiredMeasures).toEqual([])
+      })
     })
   })
 })

--- a/__tests__/registerObserver.test.js
+++ b/__tests__/registerObserver.test.js
@@ -1,4 +1,7 @@
-var { registerObserver, getRequiredMeasures } = require('../src/npm/hook')
+var {
+  registerObserver,
+  getMeasuresByComponentName
+} = require('../src/npm/hook')
 
 describe('Register Observer', () => {
   describe('The register observer function shouldnt crash', () => {
@@ -37,7 +40,7 @@ describe('utils', () => {
   let componentNames
   let measures
   let requiredMeasures
-  describe('getRequiredMeasures', () => {
+  describe('getMeasuresByComponentName', () => {
     describe('with matching `componentNames`', () => {
       beforeEach(() => {
         componentNames = ['foo']
@@ -46,7 +49,7 @@ describe('utils', () => {
             componentName: 'foo'
           }
         ]
-        requiredMeasures = getRequiredMeasures(componentNames, measures)
+        requiredMeasures = getMeasuresByComponentName(componentNames, measures)
       })
       it('should return a list of required measure', () => {
         expect(requiredMeasures).toEqual([
@@ -64,7 +67,7 @@ describe('utils', () => {
             componentName: 'bar'
           }
         ]
-        requiredMeasures = getRequiredMeasures(componentNames, measures)
+        requiredMeasures = getMeasuresByComponentName(componentNames, measures)
       })
       it('should return a list of empty measure', () => {
         expect(requiredMeasures).toEqual([])

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -71,8 +71,7 @@ const logToConsole = ({ port, components }, measures) => {
   if (!components) {
     logMeasures(port, measures)
   } else if (typeof components !== undefined && Array.isArray(components)) {
-    const requiredMeasures = getRequiredMeasures(components, measures)
-    logMeasures(port, requiredMeasures)
+    logMeasures(port, getMeasuresByComponentName(components, measures))
   }
 }
 
@@ -130,7 +129,7 @@ const send = (data, port) => {
   )
 }
 
-const getRequiredMeasures = (componentNames, measures) =>
+const getMeasuresByComponentName = (componentNames, measures) =>
   measures.reduce(
     (measuresByComponent, measure) =>
       componentNames.includes(measure.componentName)
@@ -139,4 +138,4 @@ const getRequiredMeasures = (componentNames, measures) =>
     []
   )
 
-export { registerObserver, getRequiredMeasures }
+export { registerObserver, getMeasuresByComponentName }

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -72,7 +72,6 @@ const logToConsole = ({ port, components }, measures) => {
     logMeasures(port, measures)
   } else if (typeof components !== undefined && Array.isArray(components)) {
     const requiredMeasures = getRequiredMeasures(components, measures)
-
     logMeasures(port, requiredMeasures)
   }
 }
@@ -131,20 +130,13 @@ const send = (data, port) => {
   )
 }
 
-const getRequiredMeasures = (components, measures) => {
-  let requiredMeasures = []
+const getRequiredMeasures = (componentNames, measures) =>
+  measures.reduce(
+    (measuresByComponent, measure) =>
+      componentNames.includes(measure.componentName)
+        ? [...measuresByComponent, measure]
+        : measuresByComponent,
+    []
+  )
 
-  if (!Array.isArray(components)) {
-    components = [components]
-  }
-
-  measures.forEach(measure => {
-    if (components.includes(measure.componentName)) {
-      requiredMeasures.push(measure)
-    }
-  })
-
-  return requiredMeasures
-}
-
-export { registerObserver }
+export { registerObserver, getRequiredMeasures }

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -130,12 +130,6 @@ const send = (data, port) => {
 }
 
 const getMeasuresByComponentName = (componentNames, measures) =>
-  measures.reduce(
-    (measuresByComponent, measure) =>
-      componentNames.includes(measure.componentName)
-        ? [...measuresByComponent, measure]
-        : measuresByComponent,
-    []
-  )
+  measures.filter(measure => componentNames.includes(measure.componentName))
 
 export { registerObserver, getMeasuresByComponentName }


### PR DESCRIPTION
- simplifies the implementation of `getRequiredMeasures`
- changes name of `getRequiredMeasures` to `getMatchingMeasures` since that's what we were doing