### PR TITLE
Add type definitions for registerObserver

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+interface IOptions {
+    shouldLog?: boolean;
+    port?: number;
+    components?: string[];
+}
+
+interface IMeasureDetail {
+    averageTimeSpentMs: string;
+    numberOfTimes: number;
+    totalTimeSpentMs: number;
+}
+
+interface IMeasure {
+    componentName: string; // Name of the component
+    totalTimeSpent: number; // Total time taken by the component combining all the phases
+    percentTimeSpent: string; // Percent time
+    numberOfInstances: number; // Number of instances of the component
+    mount: IMeasureDetail; // Mount time
+    render: IMeasureDetail; // Render time
+    update: IMeasureDetail; // Update time
+    unmount: IMeasureDetail; // Unmount time
+
+    // Time taken in lifecycle hooks
+    componentWillMount: IMeasureDetail;
+    componentDidMount: IMeasureDetail;
+    componentWillReceiveProps: IMeasureDetail;
+    shouldComponentUpdate: IMeasureDetail;
+    componentWillUpdate: IMeasureDetail;
+    componentDidUpdate: IMeasureDetail;
+    componentWillUnmount: IMeasureDetail;
+}
+
+declare module 'react-perf-devtool' {
+    function registerObserver(
+        options: IOptions,
+        callback?: (measures: Array<IMeasure>) => void
+    ): void
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ interface IMeasure {
 
 declare module 'react-perf-devtool' {
     function registerObserver(
-        options: IOptions,
+        options?: IOptions,
         callback?: (measures: Array<IMeasure>) => void
     ): void
 }


### PR DESCRIPTION
I was working on a React TypeScript project using your devtool and was getting compile errors against the registerObserver function because of no types. So I went ahead and created some that worked. Let me know if this works for you. 

I don't know if this package should include type definitions out of the box or if they should be accessed via the `@types` project. Thoughts on this?