### PR TITLE
refactor(registerObserver): preserve `observer` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Registering an observer is very simple and is only one function call away. Let's
 ```js
 const { registerObserver } = require('react-perf-devtool')
 
-registerObserver()
+// assign the observer to the global scope, as the GC will delete it otherwise
+window.observer = registerObserver()
 ```
 
 You can place this code inside your `index.js` file (recommended) or any other file in your app.
@@ -152,7 +153,8 @@ function callback(measures) {
   // do something with the measures
 }
 
-registerObserver({}, callback)
+// assign the observer to the global scope, as the GC will delete it otherwise
+window.observer = registerObserver({}, callback)
 ```
 
 After you've registered the observer, start your local development server and go to `http://localhost:3000/`.
@@ -215,7 +217,8 @@ function callback(measures) {
   // do something with the measures
 }
 
-registerObserver(options, callback)
+// assign the observer to the global scope, as the GC will delete it otherwise
+window.observer = registerObserver(options, callback)
 
 ReactDOM.render(<Component />, document.getElementById('root'))
 ```
@@ -331,7 +334,8 @@ function callback(measures) {
   // do something with measures
 }
 
-registerObserver(options, callback)
+// assign the observer to the global scope, as the GC will delete it otherwise
+window.observer = registerObserver(options, callback)
 ```
 
 ## Description
@@ -408,7 +412,8 @@ But now, with the help of [Performance Observer](https://developer.mozilla.org/e
 ```js
 const { registerObserver } = require('react-perf-devtool')
 
-registerObserver()
+// assign the observer to the global scope, as the GC will delete it otherwise
+window.observer = registerObserver()
 ```
 
 This observer listens to the React performance measurement event.

--- a/__tests__/registerObserver.test.js
+++ b/__tests__/registerObserver.test.js
@@ -3,35 +3,60 @@ var {
   getMeasuresByComponentName
 } = require('../src/npm/hook')
 
-describe('Register Observer', () => {
-  describe('The register observer function shouldnt crash', () => {
+describe('`registerObserver`', () => {
+  let observer
+  let callback
+  let params
+  let observerReference
+  describe('with `window.PerformanceObserver`', () => {
     beforeEach(() => {
-      window.PerformanceObserver = jest.fn(callback => ({
-        observe: () =>
-          callback({
-            getEntries: () => []
-          })
-      }))
+      observerReference = {
+        observe: jest.fn()
+      }
+      window.PerformanceObserver = jest.fn(() => observerReference)
+      callback = jest.fn()
+      observer = registerObserver(params, callback)
     })
-    test('Call register without params', () => {
-      expect(registerObserver()).toBeUndefined()
-      expect(window.PerformanceObserver).toHaveBeenCalled()
+    it('should return `observer`', () => {
+      expect(observer).toEqual(observerReference)
     })
-    test('Call register with params', () => {
-      const callback = () => {}
-      expect(
-        registerObserver({ shouldLog: true, port: 8080 }, callback)
-      ).toBeUndefined()
-      expect(window.PerformanceObserver).toHaveBeenCalled()
+    it('should call `observer.observe`', () => {
+      expect(observerReference.observe).toHaveBeenCalledTimes(1)
     })
-    test('Call register with params but without callback', () => {
-      expect(registerObserver({ shouldLog: true, port: 8080 })).toBeUndefined()
-      expect(window.PerformanceObserver).toHaveBeenCalled()
+    describe('without `params`', () => {
+      beforeEach(() => {
+        params = undefined
+      })
+      it('should call `observer.observe` with `entryTypes`', () => {
+        expect(observerReference.observe).toHaveBeenCalledWith({
+          entryTypes: ['measure']
+        })
+      })
     })
-    test('Call register without params but without callback', () => {
-      const callback = () => {}
-      expect(registerObserver(undefined, callback)).toBeUndefined()
-      expect(window.PerformanceObserver).toHaveBeenCalled()
+    describe('with `params.entryTypes`', () => {
+      beforeEach(() => {
+        params = {
+          entryTypes: ['mark']
+        }
+        callback = jest.fn()
+        observer = registerObserver(params, callback)
+      })
+      it('should call `observer.observe` with `entryTypes`', () => {
+        expect(observerReference.observe).toHaveBeenCalledWith({
+          entryTypes: ['mark']
+        })
+      })
+    })
+  })
+  describe('without `window.PerformanceObserver`', () => {
+    beforeEach(() => {
+      window.PerformanceObserver = undefined
+      callback = jest.fn()
+      params = undefined
+      observer = registerObserver(params, callback)
+    })
+    it('should return `undefined`', () => {
+      expect(observer).toEqual(undefined)
     })
   })
 })

--- a/__tests__/registerObserver.test.js
+++ b/__tests__/registerObserver.test.js
@@ -33,20 +33,6 @@ describe('`registerObserver`', () => {
         })
       })
     })
-    describe('with `params.entryTypes`', () => {
-      beforeEach(() => {
-        params = {
-          entryTypes: ['mark']
-        }
-        callback = jest.fn()
-        observer = registerObserver(params, callback)
-      })
-      it('should call `observer.observe` with `entryTypes`', () => {
-        expect(observerReference.observe).toHaveBeenCalledWith({
-          entryTypes: ['mark']
-        })
-      })
-    })
   })
   describe('without `window.PerformanceObserver`', () => {
     beforeEach(() => {

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -29,38 +29,31 @@ import { generateDataFromMeasures } from '../shared/generate'
 
   NOTE: This should only be used in development mode.
 */
-const registerObserver = (params, callback) => {
-  params = params || {}
-
-  // TODO: Is there any way to polyfill this API ?
+const registerObserver = (
+  params = {
+    entryTypes: ['measure'],
+    shouldLog: false
+  },
+  callback
+) => {
   if (window.PerformanceObserver) {
-    const { shouldLog, port, components } = params
-
-    let observer = new window.PerformanceObserver(list => {
+    const observer = new window.PerformanceObserver(list => {
+      const entries = list.getEntries()
       const measures = generateDataFromMeasures(
-        getReactPerformanceData(list.getEntries())
+        getReactPerformanceData(entries)
       )
-
-      if (callback && typeof callback === 'function') {
-        callback(measures)
-      }
-
+      if (typeof callback === 'function') callback(measures)
       window.__REACT_PERF_DEVTOOL_GLOBAL_STORE__ = {
         measures,
         length: list.getEntries().length,
         rawMeasures: list.getEntries()
       }
-
-      // For logging to console
-      if (shouldLog) {
-        logToConsole(params, measures)
-      }
+      if (params.shouldLog) logToConsole(params, measures)
     })
-
-    observer.observe({
-      entryTypes: ['measure']
-    })
+    observer.observe({ entryTypes: params.entryTypes })
+    return observer
   }
+  return undefined
 }
 
 /**

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -29,13 +29,7 @@ import { generateDataFromMeasures } from '../shared/generate'
 
   NOTE: This should only be used in development mode.
 */
-const registerObserver = (
-  params = {
-    entryTypes: ['measure'],
-    shouldLog: false
-  },
-  callback
-) => {
+const registerObserver = (params = { shouldLog: false }, callback) => {
   if (window.PerformanceObserver) {
     const observer = new window.PerformanceObserver(list => {
       const entries = list.getEntries()
@@ -50,7 +44,7 @@ const registerObserver = (
       }
       if (params.shouldLog) logToConsole(params, measures)
     })
-    observer.observe({ entryTypes: params.entryTypes })
+    observer.observe({ entryTypes: ['measure'] })
     return observer
   }
   return undefined

--- a/src/npm/hook.js
+++ b/src/npm/hook.js
@@ -45,8 +45,8 @@ const registerObserver = (
       if (typeof callback === 'function') callback(measures)
       window.__REACT_PERF_DEVTOOL_GLOBAL_STORE__ = {
         measures,
-        length: list.getEntries().length,
-        rawMeasures: list.getEntries()
+        length: entries.length,
+        rawMeasures: entries
       }
       if (params.shouldLog) logToConsole(params, measures)
     })


### PR DESCRIPTION
1. returns `observer` when calling `registerObserver`
2. supercedes #26 
3. extends tests

---

#### Tech debt

1. Missing possibility to mock `logToConsole`
2. consider using `takeRecords` or another option over `callback`
One problem I found with the current implementation of passing `callback` into `window.PerformanceObserver` is that we "leaking" or "imposing" external functions into the instantiation of `window.PerformanceObserver`, which makes it hard or rather unintuitive to mock and test. One option to consider over this is to return a promise resolving the entries of the observer, but this is anti-pattern to Observers in general. A more optimal solution is a follow up and continuation to returning the instance is having `callback` removed and allow consumers to `registerOberserver` to use [`takeRecords`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/takeRecords) which fulfills two purpose:
   - empty the store
   - process data. Given this; we give raw records back and let consumers for themselves decide how they want to process this (optimal but breaking change)